### PR TITLE
Fixing the method to get user account details

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,11 +17,10 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Install required packages
-        run: >
-          pip install -Iv ansible-core ansible-lint flake8 yamllint black rich
+        run: pip install -Iv ansible-core ansible-lint flake8 yamllint black
 
       - uses: pre-commit/action@v2.0.3
 ...

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,7 +20,8 @@ jobs:
           python-version: '3.9'
 
       - name: Install required packages
-        run: pip install -Iv ansible-core ansible-lint flake8 yamllint black
+        run: >
+          pip install -Iv ansible-core ansible-lint flake8 yamllint black rich
 
       - uses: pre-commit/action@v2.0.3
 ...

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.9'
 
       - name: Install required packages
         run: pip install -Iv ansible-core ansible-lint flake8 yamllint black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -12,13 +12,13 @@ repos:
         types:
           - yaml
   - repo: https://github.com/ansible-community/ansible-lint.git
-    rev: v5.3.0
+    rev: v5.3.2
     hooks:
       - id: ansible-lint
         types:
           - yaml
   - repo: https://github.com/psf/black
-    rev: 21.11b1
+    rev: 21.12b0
     hooks:
       - id: black
         name: black
@@ -28,7 +28,7 @@ repos:
         types:
           - python
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 3.9.2
     hooks:
       - id: flake8
         name: flake8

--- a/plugins/module_utils/api_module.py
+++ b/plugins/module_utils/api_module.py
@@ -843,17 +843,39 @@ class APIModule(AnsibleModule):
         # used in Quay are not in the internal database and are not returned
         # when using the "users" endpoint.
         #
-        # GET /api/v1/entities/user2
+        # GET /api/v1/entities/user9
         # {
         #   "results": [
         #     {
-        #       "name": "user2",
+        #       "name": "user9",
         #       "kind": "external",
-        #       "title": "user2@example.com",
+        #       "title": "user9@example.com",
         #       "avatar": {
-        #         "name": "user2",
-        #         "hash": "2b3b...95b5",
-        #         "color": "#c49c94",
+        #         "name": "user9",
+        #         "hash": "b1e7...098e",
+        #         "color": "#1f77b4",
+        #         "kind": "user"
+        #       }
+        #     },
+        #     {
+        #       "name": "user911",
+        #       "kind": "external",
+        #       "title": "user911@example.com",
+        #       "avatar": {
+        #         "name": "user911",
+        #         "hash": "5f67...3016",
+        #         "color": "#a55194",
+        #         "kind": "user"
+        #       }
+        #     },
+        #     {
+        #       "name": "user912",
+        #       "kind": "external",
+        #       "title": "user912@example.com",
+        #       "avatar": {
+        #         "name": "user912",
+        #         "hash": "7587...20ab",
+        #         "color": "#5254a3",
         #         "kind": "user"
         #       }
         #     }
@@ -865,14 +887,19 @@ class APIModule(AnsibleModule):
             exit_on_error=exit_on_error,
             user=account_name,
         )
-        if isinstance(user, dict) and len(user.get("results", [])) == 1:
-            res = user["results"][0]
-            user["name"] = res["name"]
+        if isinstance(user, dict) and len(user.get("results", [])) != 0:
+            # Search for an exact match for the username
+            for res in user["results"]:
+                if res.get("name") == account_name:
+                    break
+            else:
+                return None
+            user["name"] = account_name
             user["is_organization"] = False
             user["is_robot"] = False
             # The LDAP user account is not yet declared into the Quay internal
             # database. Add it.
-            if res["kind"] == "external":
+            if res.get("kind") == "external":
                 try:
                     self.create(
                         "user",

--- a/plugins/module_utils/api_module.py
+++ b/plugins/module_utils/api_module.py
@@ -1,4 +1,4 @@
-# Copyright: (c) 2021, Herve Quatremain <rv4m@yahoo.co.uk>
+# Copyright: (c) 2021, 2022, Herve Quatremain <rv4m@yahoo.co.uk>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 
@@ -835,14 +835,56 @@ class APIModule(AnsibleModule):
                 robot["is_robot"] = True
                 return robot
 
-        # User account
+        # User account.
+        #
+        # Uses the "entities" (search) endpoint rather than the "users"
+        # endpoint because the "users" endpoint only returns the users already
+        # defined in the internal database. LDAP users that have not yet been
+        # used in Quay are not in the internal database and are not returned
+        # when using the "users" endpoint.
+        #
+        # GET /api/v1/entities/user2
+        # {
+        #   "results": [
+        #     {
+        #       "name": "user2",
+        #       "kind": "external",
+        #       "title": "user2@example.com",
+        #       "avatar": {
+        #         "name": "user2",
+        #         "hash": "2b3b...95b5",
+        #         "color": "#c49c94",
+        #         "kind": "user"
+        #       }
+        #     }
+        #   ]
+        # }
         user = self.get_object_path(
-            "users/{user}", exit_on_error=exit_on_error, user=account_name
+            "entities/{user}",
+            query_params={"includeOrgs": False, "includeTeams": False},
+            exit_on_error=exit_on_error,
+            user=account_name,
         )
-        if isinstance(user, dict) and user:
-            user["name"] = user.get("username")
+        if isinstance(user, dict) and len(user.get("results", [])) == 1:
+            res = user["results"][0]
+            user["name"] = res["name"]
             user["is_organization"] = False
             user["is_robot"] = False
+            # The LDAP user account is not yet declared into the Quay internal
+            # database. Add it.
+            if res["kind"] == "external":
+                try:
+                    self.create(
+                        "user",
+                        user["name"],
+                        "entities/link/{user}",
+                        {},
+                        auto_exit=False,
+                        exit_on_error=False,
+                        user=user["name"],
+                    )
+                except APIModuleError:
+                    pass
             return user
         return None
 

--- a/tests/integration/targets/quay_tag/tasks/main.yml
+++ b/tests/integration/targets/quay_tag/tasks/main.yml
@@ -37,10 +37,15 @@
               {{ quay_hostname }}/ansibletestorg/ansibletestrepo:latest"
       changed_when: true
 
+    - name: Ensure podman is logged in
+      command:
+        cmd: "podman login --tls-verify=false --username {{ admin_username }}
+              --password {{ admin_password }} {{ quay_hostname }}"
+      changed_when: true
+
     - name: Ensure the image is pushed to Red Hat Quay
       command:
         cmd: "podman push --tls-verify=false --remove-signatures
-              --creds={{ admin_username }}:{{ admin_password }}
               {{ quay_hostname }}/ansibletestorg/ansibletestrepo:latest"
       changed_when: true
 


### PR DESCRIPTION
When Quay is configured for using LDAP, the user accounts that exist in LDAP might not yet be declared in the Quay internal database.
Now, if the user account is not yet in the database, then the `get_account()` method fetches it from LDAP.