### PR TITLE
Fix generating API token

### DIFF
--- a/plugins/module_utils/api_module.py
+++ b/plugins/module_utils/api_module.py
@@ -37,9 +37,7 @@ class APIModule(AnsibleModule):
     """Ansible module for managing Quay Container Registry."""
 
     AUTH_ARGSPEC = dict(
-        quay_host=dict(
-            fallback=(env_fallback, ["QUAY_HOST"]), default="http://127.0.0.1"
-        ),
+        quay_host=dict(fallback=(env_fallback, ["QUAY_HOST"]), default="http://127.0.0.1"),
         quay_token=dict(no_log=True, fallback=(env_fallback, ["QUAY_TOKEN"])),
         quay_username=dict(fallback=(env_fallback, ["QUAY_USERNAME"])),
         quay_password=dict(no_log=True, fallback=(env_fallback, ["QUAY_PASSWORD"])),
@@ -165,9 +163,7 @@ class APIModule(AnsibleModule):
         except APIModuleError as e:
             self.fail_json(msg=str(e))
         try:
-            csrf = re.search(
-                r"window.__token\s*=\s*'(.*?)';", to_text(html["body"])
-            ).group(1)
+            csrf = re.search(r"window.__token\s*=\s*'(.*?)';", to_text(html["body"])).group(1)
         except AttributeError:
             self.fail_json(msg="Cannot retrieve the CSRF token from the returned data")
 
@@ -293,9 +289,7 @@ class APIModule(AnsibleModule):
                     follow_redirects=follow_redirects,
                 )
             else:
-                response = self.session.open(
-                    method, url.geturl(), headers=headers, data=data
-                )
+                response = self.session.open(method, url.geturl(), headers=headers, data=data)
         except SSLValidationError as ssl_err:
             raise APIModuleError(
                 "Could not establish a secure connection to {host}: {error}.".format(
@@ -323,9 +317,7 @@ class APIModule(AnsibleModule):
             # If so, fail out now; this is always a failure.
             elif he.code == 401:
                 raise APIModuleError(
-                    "Authentication required for {path} (HTTP 401).".format(
-                        path=url.path
-                    )
+                    "Authentication required for {path} (HTTP 401).".format(path=url.path)
                 )
             # Sanity check: Did we get a forbidden response, which means that
             # the user isn't allowed to do this? Report that.
@@ -480,12 +472,7 @@ class APIModule(AnsibleModule):
         return ": ".join(msg_fragments)
 
     def get_object_path(
-        self,
-        endpoint,
-        query_params=None,
-        exit_on_error=True,
-        ok_error_codes=None,
-        **kwargs
+        self, endpoint, query_params=None, exit_on_error=True, ok_error_codes=None, **kwargs
     ):
         """Retrieve a single object from a GET API call.
 
@@ -1111,11 +1098,7 @@ class APIModule(AnsibleModule):
         org_details = self.get_organization(organization, exit_on_error=exit_on_error)
         if not org_details:
             return None
-        return (
-            org_details["teams"].get(team_name, None)
-            if "teams" in org_details
-            else None
-        )
+        return org_details["teams"].get(team_name, None) if "teams" in org_details else None
 
     def get_organization(self, organization, exit_on_error=True):
         """Search for the given organization.
@@ -1227,9 +1210,7 @@ class APIModule(AnsibleModule):
             return user_details
         return None
 
-    def get_tags(
-        self, namespace, repository, tag=None, digest=None, only_active_tags=True
-    ):
+    def get_tags(self, namespace, repository, tag=None, digest=None, only_active_tags=True):
         """Return the list of tags for the given repository.
 
         :param namespace: The name of the repository's namespace.
@@ -1372,9 +1353,7 @@ class APIModule(AnsibleModule):
 
 class APIModuleNoAuth(APIModule):
     AUTH_ARGSPEC = dict(
-        quay_host=dict(
-            fallback=(env_fallback, ["QUAY_HOST"]), default="http://127.0.0.1"
-        ),
+        quay_host=dict(fallback=(env_fallback, ["QUAY_HOST"]), default="http://127.0.0.1"),
         validate_certs=dict(
             type="bool",
             aliases=["verify_ssl"],

--- a/plugins/module_utils/api_module.py
+++ b/plugins/module_utils/api_module.py
@@ -37,7 +37,9 @@ class APIModule(AnsibleModule):
     """Ansible module for managing Quay Container Registry."""
 
     AUTH_ARGSPEC = dict(
-        quay_host=dict(fallback=(env_fallback, ["QUAY_HOST"]), default="http://127.0.0.1"),
+        quay_host=dict(
+            fallback=(env_fallback, ["QUAY_HOST"]), default="http://127.0.0.1"
+        ),
         quay_token=dict(no_log=True, fallback=(env_fallback, ["QUAY_TOKEN"])),
         quay_username=dict(fallback=(env_fallback, ["QUAY_USERNAME"])),
         quay_password=dict(no_log=True, fallback=(env_fallback, ["QUAY_PASSWORD"])),
@@ -49,7 +51,10 @@ class APIModule(AnsibleModule):
         ),
     )
 
-    MUTUALLY_EXCLUSIVE = [("quay_username", "quay_token"), ("quay_password", "quay_token")]
+    MUTUALLY_EXCLUSIVE = [
+        ("quay_username", "quay_token"),
+        ("quay_password", "quay_token"),
+    ]
 
     REQUIRED_TOGETHER = [("quay_username", "quay_password")]
 
@@ -160,7 +165,9 @@ class APIModule(AnsibleModule):
         except APIModuleError as e:
             self.fail_json(msg=str(e))
         try:
-            csrf = re.search(r"window.__token\s*=\s*'(.*?)';", to_text(html["body"])).group(1)
+            csrf = re.search(
+                r"window.__token\s*=\s*'(.*?)';", to_text(html["body"])
+            ).group(1)
         except AttributeError:
             self.fail_json(msg="Cannot retrieve the CSRF token from the returned data")
 
@@ -189,7 +196,9 @@ class APIModule(AnsibleModule):
             self.fail_json(msg=fail_msg)
 
         # Get the X-CSRF-Token header
-        token = response["headers"].get("X-Next-CSRF-Token")
+        # Depending on the Quay version the headers might not be in lowercase
+        headers_lower = dict((k.lower(), v) for k, v in response["headers"].items())
+        token = headers_lower.get("x-next-csrf-token")
         if token is None:
             self.fail_json(msg="Cannot retrieve the authentication token")
         return token
@@ -284,7 +293,9 @@ class APIModule(AnsibleModule):
                     follow_redirects=follow_redirects,
                 )
             else:
-                response = self.session.open(method, url.geturl(), headers=headers, data=data)
+                response = self.session.open(
+                    method, url.geturl(), headers=headers, data=data
+                )
         except SSLValidationError as ssl_err:
             raise APIModuleError(
                 "Could not establish a secure connection to {host}: {error}.".format(
@@ -312,7 +323,9 @@ class APIModule(AnsibleModule):
             # If so, fail out now; this is always a failure.
             elif he.code == 401:
                 raise APIModuleError(
-                    "Authentication required for {path} (HTTP 401).".format(path=url.path)
+                    "Authentication required for {path} (HTTP 401).".format(
+                        path=url.path
+                    )
                 )
             # Sanity check: Did we get a forbidden response, which means that
             # the user isn't allowed to do this? Report that.
@@ -467,7 +480,12 @@ class APIModule(AnsibleModule):
         return ": ".join(msg_fragments)
 
     def get_object_path(
-        self, endpoint, query_params=None, exit_on_error=True, ok_error_codes=None, **kwargs
+        self,
+        endpoint,
+        query_params=None,
+        exit_on_error=True,
+        ok_error_codes=None,
+        **kwargs
     ):
         """Retrieve a single object from a GET API call.
 
@@ -1093,7 +1111,11 @@ class APIModule(AnsibleModule):
         org_details = self.get_organization(organization, exit_on_error=exit_on_error)
         if not org_details:
             return None
-        return org_details["teams"].get(team_name, None) if "teams" in org_details else None
+        return (
+            org_details["teams"].get(team_name, None)
+            if "teams" in org_details
+            else None
+        )
 
     def get_organization(self, organization, exit_on_error=True):
         """Search for the given organization.
@@ -1205,7 +1227,9 @@ class APIModule(AnsibleModule):
             return user_details
         return None
 
-    def get_tags(self, namespace, repository, tag=None, digest=None, only_active_tags=True):
+    def get_tags(
+        self, namespace, repository, tag=None, digest=None, only_active_tags=True
+    ):
         """Return the list of tags for the given repository.
 
         :param namespace: The name of the repository's namespace.
@@ -1348,7 +1372,9 @@ class APIModule(AnsibleModule):
 
 class APIModuleNoAuth(APIModule):
     AUTH_ARGSPEC = dict(
-        quay_host=dict(fallback=(env_fallback, ["QUAY_HOST"]), default="http://127.0.0.1"),
+        quay_host=dict(
+            fallback=(env_fallback, ["QUAY_HOST"]), default="http://127.0.0.1"
+        ),
         validate_certs=dict(
             type="bool",
             aliases=["verify_ssl"],

--- a/plugins/modules/quay_api_token.py
+++ b/plugins/modules/quay_api_token.py
@@ -223,11 +223,15 @@ def main():
     except APIModuleError as e:
         module.fail_json(msg=str(e))
 
-    if "Location" not in response["headers"]:
-        module.fail_json(msg="Cannot retrieve the OAuth access token from the returned data")
+    # Depending on the Quay version the headers might not be in lowercase
+    headers_lower = dict((k.lower(), v) for k, v in response["headers"].items())
+    if "location" not in headers_lower:
+        module.fail_json(
+            msg="Cannot retrieve the OAuth access token from the returned data"
+        )
 
     try:
-        token = re.search("access_token=(.*?)&", response["headers"]["Location"]).group(1)
+        token = re.search("access_token=(.*?)&", headers_lower["location"]).group(1)
     except AttributeError:
         module.fail_json(msg="Cannot retrieve the CSRF token from the returned data")
 

--- a/plugins/modules/quay_api_token.py
+++ b/plugins/modules/quay_api_token.py
@@ -226,9 +226,7 @@ def main():
     # Depending on the Quay version the headers might not be in lowercase
     headers_lower = dict((k.lower(), v) for k, v in response["headers"].items())
     if "location" not in headers_lower:
-        module.fail_json(
-            msg="Cannot retrieve the OAuth access token from the returned data"
-        )
+        module.fail_json(msg="Cannot retrieve the OAuth access token from the returned data")
 
     try:
         token = re.search("access_token=(.*?)&", headers_lower["location"]).group(1)


### PR DESCRIPTION
Recent releases of Quay seem to have switched to using lower case header names in the response for this API. To stay backwards compatible with older Quay releases this code changes all response header keys to lower case for extracting the required header.

Fixes #23

Other changes are cosmetic due to running `black`.